### PR TITLE
Fix failure for Click verions above 7.1

### DIFF
--- a/tests/test_cli_assist.py
+++ b/tests/test_cli_assist.py
@@ -106,7 +106,7 @@ def assist_harness(tmp_path: Path, monkeypatch) -> AssistHarness:
     monkeypatch.setattr(cli_module, "IntentRouter", StubRouter)
     monkeypatch.chdir(repo_root)
 
-    runner = CliRunner(mix_stderr=False)
+    runner = CliRunner()
     return AssistHarness(repo_root=repo_root, runner=runner, _rules=router_rules, _client_ref=client_ref)
 
 


### PR DESCRIPTION
mix_stderr was removed from click versions >= 7.1 and usages of this arg result in failures when running `pytest` command

click changelog: https://click.palletsprojects.com/en/stable/changes/#version-7-1

related issue: https://github.com/pallets/click/issues/1435

fail log:

<img width="1918" height="769" alt="image" src="https://github.com/user-attachments/assets/0f9e1fdd-5d94-4c16-87fd-69425265c8a9" />

