### PR TITLE
Shim tree-sitter import for Python 3.12 and remove doc

### DIFF
--- a/ai_dev_agent/core/utils/config.py
+++ b/ai_dev_agent/core/utils/config.py
@@ -98,6 +98,12 @@ class Settings:
     search_max_results: int = 100
     disable_context_pruner: bool = False
     always_use_planning: bool = False
+    context_pruner_max_total_tokens: int = 12_000
+    context_pruner_trigger_tokens: Optional[int] = None
+    context_pruner_trigger_ratio: float = 0.8
+    context_pruner_keep_recent_messages: int = 10
+    context_pruner_summary_max_chars: int = 1_200
+    context_pruner_max_event_history: int = 10
 
     def ensure_state_dir(self) -> None:
         """Ensure the directory for the state file exists."""
@@ -161,9 +167,14 @@ def _load_from_env(prefix: str = "DEVAGENT_") -> Dict[str, Any]:
             "keep_last_assistant_messages",
             "fs_read_default_max_lines",
             "search_max_results",
+            "context_pruner_max_total_tokens",
+            "context_pruner_trigger_tokens",
+            "context_pruner_keep_recent_messages",
+            "context_pruner_summary_max_chars",
+            "context_pruner_max_event_history",
         }:
             env[field] = int(value)
-        elif field in {"patch_coverage_target"}:
+        elif field in {"patch_coverage_target", "context_pruner_trigger_ratio"}:
             env[field] = float(value)
         elif field == "shell_session_timeout":
             env[field] = float(value)

--- a/ai_dev_agent/session/summarizer.py
+++ b/ai_dev_agent/session/summarizer.py
@@ -1,0 +1,112 @@
+"""Conversation summarization helpers used by the session context pruner."""
+from __future__ import annotations
+
+import logging
+from typing import Protocol, Sequence
+
+from ai_dev_agent.core.utils.context_budget import summarize_text
+from ai_dev_agent.providers.llm.base import LLMClient, LLMError, Message
+
+LOGGER = logging.getLogger(__name__)
+
+
+class ConversationSummarizer(Protocol):
+    """Protocol implemented by conversation summarizers."""
+
+    def summarize(self, messages: Sequence[Message], *, max_chars: int) -> str:
+        """Return a concise summary of ``messages`` within ``max_chars`` characters."""
+
+
+def _format_messages(messages: Sequence[Message]) -> str:
+    """Return a deterministic plain-text representation of chat messages."""
+
+    lines: list[str] = []
+    for message in messages:
+        content = (message.content or "").strip()
+        if not content:
+            continue
+        role = message.role.capitalize()
+        lines.append(f"{role}: {content}")
+    return "\n".join(lines)
+
+
+class HeuristicConversationSummarizer:
+    """Fallback summarizer that mirrors the previous deterministic behaviour."""
+
+    def summarize(self, messages: Sequence[Message], *, max_chars: int) -> str:
+        formatted = _format_messages(messages)
+        if not formatted:
+            return "(no additional context retained)"
+        return summarize_text(formatted, max_chars)
+
+
+DEFAULT_SYSTEM_PROMPT = (
+    "You are an expert senior engineer helping to condense a conversation between "
+    "a developer and their coding assistant. Capture the key goals, approaches, "
+    "decisions, and remaining follow-ups so another engineer can quickly get back "
+    "up to speed. Be precise and avoid embellishment."
+)
+
+DEFAULT_USER_TEMPLATE = (
+    "Summarize the following conversation. Focus on:\n"
+    "- Current objective or task\n"
+    "- Progress made and important commands\n"
+    "- Decisions, constraints, or notable discoveries\n"
+    "- Remaining follow-ups or open questions\n\n"
+    "Write 3-5 bullet points using concise sentences. Keep the response within {max_chars} "
+    "characters. Conversation:\n{conversation}"
+)
+
+
+class LLMConversationSummarizer:
+    """Summarizer backed by an LLM client with heuristic fallback."""
+
+    def __init__(
+        self,
+        client: LLMClient,
+        *,
+        system_prompt: str | None = None,
+        user_template: str | None = None,
+        max_tokens: int = 384,
+        fallback: ConversationSummarizer | None = None,
+    ) -> None:
+        self._client = client
+        self._system_prompt = system_prompt or DEFAULT_SYSTEM_PROMPT
+        self._user_template = user_template or DEFAULT_USER_TEMPLATE
+        self._max_tokens = max_tokens
+        self._fallback = fallback or HeuristicConversationSummarizer()
+
+    def summarize(self, messages: Sequence[Message], *, max_chars: int) -> str:
+        formatted = _format_messages(messages)
+        if not formatted:
+            return self._fallback.summarize(messages, max_chars=max_chars)
+
+        prompt = [
+            Message(role="system", content=self._system_prompt),
+            Message(
+                role="user",
+                content=self._user_template.format(
+                    conversation=formatted,
+                    max_chars=max_chars,
+                ),
+            ),
+        ]
+
+        try:
+            summary = self._client.complete(prompt, temperature=0.0, max_tokens=self._max_tokens)
+        except LLMError as exc:
+            LOGGER.warning("LLM summarizer failed, falling back to heuristic: %s", exc)
+            return self._fallback.summarize(messages, max_chars=max_chars)
+
+        summary = (summary or "").strip()
+        if not summary:
+            return self._fallback.summarize(messages, max_chars=max_chars)
+
+        return summarize_text(summary, max_chars)
+
+
+__all__ = [
+    "ConversationSummarizer",
+    "HeuristicConversationSummarizer",
+    "LLMConversationSummarizer",
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+setuptools>=65
+tree-sitter==0.20.1
+tree-sitter-languages>=1.10

--- a/tests/test_cli_context_config.py
+++ b/tests/test_cli_context_config.py
@@ -1,0 +1,50 @@
+"""Tests for translating CLI settings into context pruning configuration."""
+
+from ai_dev_agent.cli.utils import _build_context_pruning_config_from_settings
+from ai_dev_agent.core.utils.config import Settings
+
+
+def test_build_context_pruning_config_defaults() -> None:
+    settings = Settings()
+
+    config = _build_context_pruning_config_from_settings(settings)
+
+    expected_trigger = int(
+        settings.context_pruner_max_total_tokens * settings.context_pruner_trigger_ratio
+    )
+    assert config.max_total_tokens == settings.context_pruner_max_total_tokens
+    assert config.trigger_tokens == expected_trigger
+    assert config.keep_recent_messages == settings.context_pruner_keep_recent_messages
+    assert config.summary_max_chars == settings.context_pruner_summary_max_chars
+    assert config.max_event_history == settings.context_pruner_max_event_history
+
+
+def test_build_context_pruning_config_clamps_values() -> None:
+    settings = Settings(
+        context_pruner_max_total_tokens=5_000,
+        context_pruner_trigger_ratio=5.0,
+        context_pruner_keep_recent_messages=1,
+        context_pruner_summary_max_chars=0,
+        context_pruner_max_event_history=0,
+    )
+
+    config = _build_context_pruning_config_from_settings(settings)
+
+    assert config.max_total_tokens == 5_000
+    assert config.trigger_tokens == 5_000
+    assert config.keep_recent_messages == 2
+    assert config.summary_max_chars == 1
+    assert config.max_event_history == 1
+
+
+def test_build_context_pruning_config_respects_explicit_trigger_tokens() -> None:
+    settings = Settings(
+        context_pruner_max_total_tokens=2_000,
+        context_pruner_trigger_tokens=1_200,
+        context_pruner_trigger_ratio=0.2,
+    )
+
+    config = _build_context_pruning_config_from_settings(settings)
+
+    assert config.trigger_tokens == 1_200
+    assert config.max_total_tokens == 2_000


### PR DESCRIPTION
## Summary
- shim the tree-sitter import path so Python 3.12 environments automatically expose the legacy distutils modules via setuptools
- add setuptools to the requirements alongside the tree-sitter packages and drop the session context management documentation per request

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68ded100738c83258f73c4a08df8688f