### PR TITLE
fix(cli): stabilize prompt input in narrow terminals

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -43,6 +43,7 @@
         "ink": "^6.8.0",
         "react": "^19.2.4",
         "smol-toml": "^1.3.0",
+        "string-width": "^8.2.0",
       },
       "devDependencies": {
         "eslint": "^9.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -24,7 +24,8 @@
     "cli-highlight": "^2.1.11",
     "ink": "^6.8.0",
     "react": "^19.2.4",
-    "smol-toml": "^1.3.0"
+    "smol-toml": "^1.3.0",
+    "string-width": "^8.2.0"
   },
   "devDependencies": {
     "vitest": "^3.0.0",

--- a/packages/cli/src/tui/App.test.ts
+++ b/packages/cli/src/tui/App.test.ts
@@ -87,6 +87,11 @@ async function typeAndSubmit(stdin: TestInput, text: string): Promise<void> {
   stdin.write("\r");
 }
 
+async function insertModifiedReturn(stdin: TestInput): Promise<void> {
+  stdin.write("\x1b\r");
+  await settle();
+}
+
 function renderForTest(
   node: React.ReactElement,
   options?: { readonly columns?: number },
@@ -943,6 +948,44 @@ describe("interactive completion notices", () => {
     const output = view.stdout.readAll();
     expect(countPromptPlaceholders(output)).toBe(2);
     expect(output).toContain("Commands: /clear (reset)");
+  });
+
+  it("submits multiline prompts when modified Return inserts a newline", async () => {
+    let submittedQuery: string | null = null;
+    const view = renderForTest(
+      React.createElement(App, {
+        bus: new EventBus(),
+        model: "test-model",
+        approvalMode: "autopilot",
+        cwd: "/tmp/devagent",
+        onClear: () => {},
+        onCycleApprovalMode: () => {},
+        onQuery: async (query) => {
+          submittedQuery = query;
+          return {
+            iterations: 1,
+            toolCalls: 0,
+            lastText: "done",
+            status: "success" as const,
+          };
+        },
+      }),
+      { columns: 28 },
+    );
+
+    await settle();
+    view.stdin.write("alpha");
+    await settle();
+    await insertModifiedReturn(view.stdin);
+    view.stdin.write("beta");
+    await settle();
+    view.stdin.write("\r");
+    await waitForRenders();
+
+    expect(submittedQuery).toBe("alpha\nbeta");
+
+    const output = stripAnsi(view.stdout.readAll());
+    expect(output).toContain("done");
   });
 
   it("renders markdown tables cleanly inside the assistant card", async () => {

--- a/packages/cli/src/tui/App.tsx
+++ b/packages/cli/src/tui/App.tsx
@@ -27,7 +27,7 @@ import {
   makeErrorPart,
 } from "../transcript-presenter.js";
 
-export const TUI_HELP_MESSAGE = "Commands: /clear (reset), /continue (resume work), /sessions (history), /exit (quit) │ Embedded shortcuts can appear anywhere: /review, /simplify │ Shift+Enter for newline │ Shift+Tab toggles safety mode";
+export const TUI_HELP_MESSAGE = "Commands: /clear (reset), /continue (resume work), /sessions (history), /exit (quit) │ Embedded shortcuts can appear anywhere: /review, /simplify │ Shift+Enter or Option+Enter for newline │ Shift+Tab toggles safety mode";
 export const ITERATION_LIMIT_NOTICE = "Iteration limit exhausted. Type /continue to proceed.";
 
 // ─── Types ──────────────────────────────────────────────────

--- a/packages/cli/src/tui/PromptInput.test.ts
+++ b/packages/cli/src/tui/PromptInput.test.ts
@@ -2,6 +2,7 @@ import { mkdtempSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { describe, expect, it } from "vitest";
+import stringWidth from "string-width";
 
 import { TUI_HELP_MESSAGE } from "./App.js";
 import {
@@ -75,6 +76,26 @@ describe("PromptInput layout helpers", () => {
       { prefix: "… ", text: "", cursorOffset: 0, dim: false },
       { prefix: "… ", text: "there", cursorOffset: null, dim: false },
     ]);
+  });
+
+  it("wraps emoji without splitting surrogate pairs", () => {
+    const rows = buildPromptRows("😀😀😀", 4, "placeholder", 4);
+
+    expect(rows).toEqual([
+      { prefix: "❯ ", text: "😀😀", cursorOffset: null, dim: false },
+      { prefix: "… ", text: "😀", cursorOffset: 0, dim: false },
+    ]);
+    expect(rows.every((row) => stringWidth(row.text) <= 4)).toBe(true);
+  });
+
+  it("wraps full-width CJK characters by terminal cell width", () => {
+    const rows = buildPromptRows("你好a", 2, "placeholder", 4);
+
+    expect(rows).toEqual([
+      { prefix: "❯ ", text: "你好", cursorOffset: null, dim: false },
+      { prefix: "… ", text: "a", cursorOffset: 0, dim: false },
+    ]);
+    expect(rows.map((row) => stringWidth(row.text))).toEqual([4, 1]);
   });
 });
 

--- a/packages/cli/src/tui/PromptInput.test.ts
+++ b/packages/cli/src/tui/PromptInput.test.ts
@@ -4,7 +4,12 @@ import { tmpdir } from "node:os";
 import { describe, expect, it } from "vitest";
 
 import { TUI_HELP_MESSAGE } from "./App.js";
-import { getCompletions, SLASH_COMMANDS } from "./PromptInput.js";
+import {
+  buildPromptRows,
+  getCompletions,
+  shouldInsertPromptNewline,
+  SLASH_COMMANDS,
+} from "./PromptInput.js";
 import { cycleApprovalMode, resolvePromptTabAction } from "./shared.js";
 
 describe("PromptInput slash completions", () => {
@@ -37,7 +42,39 @@ describe("TUI help message", () => {
     expect(TUI_HELP_MESSAGE).toContain("anywhere");
     expect(TUI_HELP_MESSAGE).toContain("/clear");
     expect(TUI_HELP_MESSAGE).toContain("/sessions");
+    expect(TUI_HELP_MESSAGE).toContain("Shift+Enter");
+    expect(TUI_HELP_MESSAGE).toContain("Option+Enter");
     expect(TUI_HELP_MESSAGE).toContain("Shift+Tab");
+  });
+});
+
+describe("PromptInput layout helpers", () => {
+  it("treats modified Return keys as newline insertion", () => {
+    expect(shouldInsertPromptNewline({ return: true, shift: true })).toBe(true);
+    expect(shouldInsertPromptNewline({ return: true, meta: true })).toBe(true);
+    expect(shouldInsertPromptNewline({ return: true, super: true })).toBe(true);
+    expect(shouldInsertPromptNewline({ return: true, hyper: true })).toBe(true);
+    expect(shouldInsertPromptNewline({ return: true })).toBe(false);
+    expect(shouldInsertPromptNewline({ shift: true })).toBe(false);
+  });
+
+  it("wraps long prompt text into explicit continuation rows", () => {
+    const rows = buildPromptRows("abcdefghij", 5, "placeholder", 5);
+
+    expect(rows).toEqual([
+      { prefix: "❯ ", text: "abcde", cursorOffset: null, dim: false },
+      { prefix: "… ", text: "fghij", cursorOffset: 0, dim: false },
+    ]);
+  });
+
+  it("keeps explicit blank lines as continuation rows", () => {
+    const rows = buildPromptRows("hi\n\nthere", 3, "placeholder", 5);
+
+    expect(rows).toEqual([
+      { prefix: "❯ ", text: "hi", cursorOffset: null, dim: false },
+      { prefix: "… ", text: "", cursorOffset: 0, dim: false },
+      { prefix: "… ", text: "there", cursorOffset: null, dim: false },
+    ]);
   });
 });
 

--- a/packages/cli/src/tui/PromptInput.tsx
+++ b/packages/cli/src/tui/PromptInput.tsx
@@ -19,6 +19,7 @@ import React, { useRef, useState } from "react";
 import { readdirSync } from "node:fs";
 import { join, dirname, basename } from "node:path";
 import { Box, Text, useInput, useStdout } from "ink";
+import stringWidth from "string-width";
 import { getApprovalModeColor, resolvePromptTabAction } from "./shared.js";
 
 export const SLASH_COMMANDS = [
@@ -36,6 +37,7 @@ export const SLASH_COMMANDS = [
 const FIRST_PROMPT_PREFIX = "❯ ";
 const CONTINUATION_PROMPT_PREFIX = "… ";
 const INPUT_FRAME_WIDTH = 6;
+const GRAPHEME_SEGMENTER = new Intl.Segmenter(undefined, { granularity: "grapheme" });
 
 interface PromptInputKey {
   readonly return?: boolean;
@@ -52,6 +54,12 @@ interface PromptRow {
   readonly dim: boolean;
 }
 
+interface WrappedPromptChunk {
+  readonly text: string;
+  readonly start: number;
+  readonly end: number;
+}
+
 interface PromptInputProps {
   readonly onSubmit: (value: string) => void;
   readonly onCycleApprovalMode?: () => void;
@@ -65,14 +73,47 @@ export function shouldInsertPromptNewline(key: PromptInputKey): boolean {
   return Boolean(key.return && (key.shift || key.meta || key.super || key.hyper));
 }
 
-function wrapPromptLine(line: string, contentWidth: number): string[] {
-  const width = Math.max(1, contentWidth);
-  if (line.length === 0) return [""];
+function splitGraphemes(line: string): Array<{ readonly text: string; readonly start: number; readonly end: number }> {
+  return Array.from(
+    GRAPHEME_SEGMENTER.segment(line),
+    ({ segment, index }) => ({
+      text: segment,
+      start: index,
+      end: index + segment.length,
+    }),
+  );
+}
 
-  const rows: string[] = [];
-  for (let index = 0; index < line.length; index += width) {
-    rows.push(line.slice(index, index + width));
+function wrapPromptLine(line: string, contentWidth: number): WrappedPromptChunk[] {
+  const width = Math.max(1, contentWidth);
+  if (line.length === 0) return [{ text: "", start: 0, end: 0 }];
+
+  const rows: WrappedPromptChunk[] = [];
+  const graphemes = splitGraphemes(line);
+  let rowText = "";
+  let rowWidth = 0;
+  let rowStart = graphemes[0]!.start;
+  let rowEnd = graphemes[0]!.start;
+
+  for (const grapheme of graphemes) {
+    const graphemeWidth = stringWidth(grapheme.text);
+
+    if (rowText.length > 0 && rowWidth + graphemeWidth > width) {
+      rows.push({ text: rowText, start: rowStart, end: rowEnd });
+      rowText = "";
+      rowWidth = 0;
+    }
+
+    if (rowText.length === 0) {
+      rowStart = grapheme.start;
+    }
+
+    rowText += grapheme.text;
+    rowWidth += graphemeWidth;
+    rowEnd = grapheme.end;
   }
+
+  rows.push({ text: rowText, start: rowStart, end: rowEnd });
   return rows;
 }
 
@@ -102,11 +143,10 @@ export function buildPromptRows(
 
   for (const [lineIndex, line] of logicalLines.entries()) {
     const chunks = wrapPromptLine(line, contentWidth);
-    let localOffset = 0;
 
     for (const [chunkIndex, chunk] of chunks.entries()) {
-      const rowStart = globalOffset + localOffset;
-      const rowEnd = rowStart + chunk.length;
+      const rowStart = globalOffset + chunk.start;
+      const rowEnd = globalOffset + chunk.end;
       const isLastChunk = chunkIndex === chunks.length - 1;
       const cursorOffset = rowContainsCursor(cursorPos, rowStart, rowEnd, isLastChunk)
         ? cursorPos - rowStart
@@ -114,13 +154,12 @@ export function buildPromptRows(
 
       rows.push({
         prefix: visualRowIndex === 0 ? FIRST_PROMPT_PREFIX : CONTINUATION_PROMPT_PREFIX,
-        text: chunk,
+        text: chunk.text,
         cursorOffset,
         dim,
       });
 
       visualRowIndex += 1;
-      localOffset += chunk.length;
     }
 
     globalOffset += line.length;

--- a/packages/cli/src/tui/PromptInput.tsx
+++ b/packages/cli/src/tui/PromptInput.tsx
@@ -10,15 +10,15 @@
  * - Bordered box (round style, gray border)
  * - ❯ prompt indicator (cyan)
  * - Visible cursor (inverted character at cursor position)
- * - Multi-line: Shift+Enter, continuation with … prefix
+ * - Multi-line: modified Return inserts a newline, continuation with … prefix
  * - History: Up/Down arrows
  * - Tab completion: slash commands + file paths
  */
 
-import React, { useState, useRef } from "react";
+import React, { useRef, useState } from "react";
 import { readdirSync } from "node:fs";
 import { join, dirname, basename } from "node:path";
-import { Box, Text, useInput } from "ink";
+import { Box, Text, useInput, useStdout } from "ink";
 import { getApprovalModeColor, resolvePromptTabAction } from "./shared.js";
 
 export const SLASH_COMMANDS = [
@@ -33,6 +33,25 @@ export const SLASH_COMMANDS = [
   "/quit",
 ];
 
+const FIRST_PROMPT_PREFIX = "❯ ";
+const CONTINUATION_PROMPT_PREFIX = "… ";
+const INPUT_FRAME_WIDTH = 6;
+
+interface PromptInputKey {
+  readonly return?: boolean;
+  readonly shift?: boolean;
+  readonly meta?: boolean;
+  readonly super?: boolean;
+  readonly hyper?: boolean;
+}
+
+interface PromptRow {
+  readonly prefix: string;
+  readonly text: string;
+  readonly cursorOffset: number | null;
+  readonly dim: boolean;
+}
+
 interface PromptInputProps {
   readonly onSubmit: (value: string) => void;
   readonly onCycleApprovalMode?: () => void;
@@ -40,6 +59,105 @@ interface PromptInputProps {
   readonly history?: ReadonlyArray<string>;
   readonly cwd?: string;
   readonly approvalMode?: string;
+}
+
+export function shouldInsertPromptNewline(key: PromptInputKey): boolean {
+  return Boolean(key.return && (key.shift || key.meta || key.super || key.hyper));
+}
+
+function wrapPromptLine(line: string, contentWidth: number): string[] {
+  const width = Math.max(1, contentWidth);
+  if (line.length === 0) return [""];
+
+  const rows: string[] = [];
+  for (let index = 0; index < line.length; index += width) {
+    rows.push(line.slice(index, index + width));
+  }
+  return rows;
+}
+
+function rowContainsCursor(
+  cursorPos: number,
+  rowStart: number,
+  rowEnd: number,
+  isLastChunk: boolean,
+): boolean {
+  if (cursorPos < rowStart || cursorPos > rowEnd) return false;
+  if (cursorPos === rowEnd && !isLastChunk) return false;
+  return true;
+}
+
+export function buildPromptRows(
+  value: string,
+  cursorPos: number,
+  placeholder: string,
+  contentWidth: number,
+): PromptRow[] {
+  const promptText = value.length > 0 ? value : placeholder;
+  const dim = value.length === 0;
+  const logicalLines = promptText.split("\n");
+  const rows: PromptRow[] = [];
+  let visualRowIndex = 0;
+  let globalOffset = 0;
+
+  for (const [lineIndex, line] of logicalLines.entries()) {
+    const chunks = wrapPromptLine(line, contentWidth);
+    let localOffset = 0;
+
+    for (const [chunkIndex, chunk] of chunks.entries()) {
+      const rowStart = globalOffset + localOffset;
+      const rowEnd = rowStart + chunk.length;
+      const isLastChunk = chunkIndex === chunks.length - 1;
+      const cursorOffset = rowContainsCursor(cursorPos, rowStart, rowEnd, isLastChunk)
+        ? cursorPos - rowStart
+        : null;
+
+      rows.push({
+        prefix: visualRowIndex === 0 ? FIRST_PROMPT_PREFIX : CONTINUATION_PROMPT_PREFIX,
+        text: chunk,
+        cursorOffset,
+        dim,
+      });
+
+      visualRowIndex += 1;
+      localOffset += chunk.length;
+    }
+
+    globalOffset += line.length;
+    if (lineIndex < logicalLines.length - 1) {
+      globalOffset += 1;
+    }
+  }
+
+  return rows;
+}
+
+function renderPromptText(row: PromptRow): React.ReactElement {
+  if (row.cursorOffset === null) {
+    return row.dim ? <Text dimColor>{row.text}</Text> : <Text>{row.text}</Text>;
+  }
+
+  const before = row.text.slice(0, row.cursorOffset);
+  const atCursor = row.text[row.cursorOffset] ?? " ";
+  const after = row.text.slice(row.cursorOffset + 1);
+
+  if (row.dim) {
+    return (
+      <Text>
+        <Text dimColor>{before}</Text>
+        <Text inverse>{atCursor}</Text>
+        <Text dimColor>{after}</Text>
+      </Text>
+    );
+  }
+
+  return (
+    <Text>
+      {before}
+      <Text inverse>{atCursor}</Text>
+      {after}
+    </Text>
+  );
 }
 
 export function PromptInput({
@@ -56,11 +174,22 @@ export function PromptInput({
   const [completions, setCompletions] = useState<string[]>([]);
   const [completionIndex, setCompletionIndex] = useState(0);
   const savedInputRef = useRef("");
+  const { stdout } = useStdout();
   const accentColor = getApprovalModeColor(approvalMode);
+  const contentWidth = Math.max(1, (stdout.columns ?? 80) - INPUT_FRAME_WIDTH);
+  const promptRows = buildPromptRows(value, cursorPos, placeholder, contentWidth);
 
   useInput((input, key) => {
-    // Submit on Enter (without Shift)
-    if (key.return && !key.shift) {
+    if (shouldInsertPromptNewline(key)) {
+      const before = value.slice(0, cursorPos);
+      const after = value.slice(cursorPos);
+      setValue(before + "\n" + after);
+      setCursorPos(cursorPos + 1);
+      return;
+    }
+
+    // Submit on plain Enter
+    if (key.return) {
       const trimmed = value.trim();
       if (trimmed) {
         onSubmit(trimmed);
@@ -69,15 +198,6 @@ export function PromptInput({
         setHistoryIndex(-1);
         savedInputRef.current = "";
       }
-      return;
-    }
-
-    // Newline on Shift+Enter
-    if (key.return && key.shift) {
-      const before = value.slice(0, cursorPos);
-      const after = value.slice(cursorPos);
-      setValue(before + "\n" + after);
-      setCursorPos(cursorPos + 1);
       return;
     }
 
@@ -161,69 +281,16 @@ export function PromptInput({
     }
   });
 
-  // Render the text with an inverted cursor character
-  const renderWithCursor = (): React.ReactElement => {
-    if (!value) {
-      return (
-        <Text>
-          <Text inverse>{placeholder[0] ?? " "}</Text>
-          <Text dimColor>{placeholder.slice(1)}</Text>
-        </Text>
-      );
-    }
-
-    const before = value.slice(0, cursorPos);
-    const atCursor = value[cursorPos] ?? " ";
-    const after = value.slice(cursorPos + 1);
-
-    return (
-      <Text>
-        {before}<Text inverse>{atCursor}</Text>{after}
-      </Text>
-    );
-  };
-
-  const lines = value.split("\n");
-  const isMultiLine = lines.length > 1;
-
-  // For multi-line, render each line with cursor on the correct one
-  const renderMultiLine = (): React.ReactElement[] => {
-    let charOffset = 0;
-    return lines.map((line, i) => {
-      const lineStart = charOffset;
-      const lineEnd = charOffset + line.length;
-      charOffset = lineEnd + 1; // +1 for \n
-
-      const cursorInLine = cursorPos >= lineStart && cursorPos <= lineEnd;
-      const localCursor = cursorPos - lineStart;
-
-      return (
-        <Box key={i}>
-          <Text color={accentColor}>{i === 0 ? "❯ " : "… "}</Text>
-          {cursorInLine ? (
-            <Text>
-              {line.slice(0, localCursor)}<Text inverse>{line[localCursor] ?? " "}</Text>{line.slice(localCursor + 1)}
-            </Text>
-          ) : (
-            <Text>{line}</Text>
-          )}
-        </Box>
-      );
-    });
-  };
-
-    return (
-      <Box flexDirection="column">
-      <Box borderStyle="round" borderColor={accentColor} paddingLeft={1} paddingRight={1}>
+  return (
+    <Box flexDirection="column">
+      <Box borderStyle="round" borderColor={accentColor} paddingLeft={1} paddingRight={1} width="100%">
         <Box flexDirection="column" flexGrow={1}>
-          {isMultiLine ? (
-            renderMultiLine()
-          ) : (
-            <Box>
-              <Text color={accentColor}>❯ </Text>
-              {renderWithCursor()}
+          {promptRows.map((row, index) => (
+            <Box key={`${index}-${row.prefix}`}>
+              <Text color={accentColor}>{row.prefix}</Text>
+              {renderPromptText(row)}
             </Box>
-          )}
+          ))}
         </Box>
       </Box>
       {completions.length > 1 && (

--- a/packages/cli/src/tui/Welcome.tsx
+++ b/packages/cli/src/tui/Welcome.tsx
@@ -45,7 +45,7 @@ export function Welcome({ model, version }: WelcomeProps): React.ReactElement {
         <Box flexDirection="column" marginTop={1}>
           <Text dimColor>  💡 Tips:</Text>
           <Text dimColor>  • Ctrl+K opens the command palette</Text>
-          <Text dimColor>  • Shift+Enter for multi-line input</Text>
+          <Text dimColor>  • Shift+Enter or Option+Enter for multi-line input</Text>
           <Text dimColor>  • Tab completes slash commands and file paths</Text>
           <Text dimColor>  • Shift+Tab toggles default and autopilot</Text>
           <Text dimColor>  • Type /continue after an iteration-limit pause</Text>


### PR DESCRIPTION
## Summary
- render prompt input as explicit visual rows so narrow terminals no longer rely on soft-wrap inside the bordered box
- allow modified Return (including Option+Return) to insert a newline while plain Return still submits
- align the TUI shortcut copy with the implemented multiline input behavior

## Root cause
- the previous input view delegated line wrapping to terminal layout, which caused border overlap and scrollback churn in narrow windows
- newline insertion only checked `Shift+Enter`, while Ink exposes other modified Return paths such as macOS Option+Return

## Testing
- `bun run typecheck`
- `cd packages/cli && bun run test -- src/tui/PromptInput.test.ts src/tui/App.test.ts`
- `bun run build`
- `bun run test`

Fixes #31
Fixes #32
Fixes #33
